### PR TITLE
Add twitch account auth to disable embedded ads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=builder /install /usr/local
 ADD streamlink-recorder.py /
 
 # Configure entrypoint with environment variables (only user is mandatory)
-ENTRYPOINT python ./streamlink-recorder.py -user=${user} -timer=${timer} -quality=${quality} -clientid=${clientid} -clientsecret=${clientsecret} -slackid=${slackid} -gamelist="${gamelist}"
+ENTRYPOINT python ./streamlink-recorder.py -user=${user} -timer=${timer} -quality=${quality} -clientid=${clientid} -clientsecret=${clientsecret} -slackid=${slackid} -gamelist="${gamelist}" -twitchaccountauth=${twitchaccountauth}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I'm also interested with new projects for automation of daily popular tasks, don
 
 ## 1.9.0 - 1.9.1
 Move to python 3.11
-Various improvements to project, cleanup and dependencise management
+Various improvements to project, cleanup and dependencies management
 
 ## 1.8.0 - 1.8.5
 Full rework with support of OAuth2 token management
@@ -69,23 +69,34 @@ Fill in twitch clientid to interact with twitch API and retrieve status of strea
 
     clientid=xxxxxxxx
 
+## clientsecret
+Fill in twitch clientsecret to interact with twitch API and retrieve status of stream from stream list
+
+    clientsecret=xxxxxxxx
+
+## twitchaccountauth
+Fill in twitch account token(it is different from client token)
+
+This is for disabling embedded ads, if you're a subscriber of the target streamer.
+
+You can find how to get this token on [Streamlink Documentation](https://streamlink.github.io/cli/plugins/twitch.html).
+
+    twitchaccountauth=xxxxxxxxxx
+
 ## slackid
 Fill in slack if you want recod start/stop notification
 
     slackid=xxxxxxxxx
 
 # Docker
-
     docker run -d --rm \
     -v twitch:/download \
-    -u 1027:100 \
     -e timer=360 \
     -e user=heromarine \
     -e quality=best \
     -e clientid=XxX \
+    -e clientsecret=XxX \
     -e slackid=XxX \
-    -v twitch:/download \
-    -u 1027:100 \
     liofal/streamlink:latest
 
 # Compose

--- a/clientid.env.example
+++ b/clientid.env.example
@@ -6,3 +6,7 @@ clientsecret=XxX
 # You can create it from 
 # https://api.slack.com/apps
 slackid=XxX
+
+# You can find how to get it from
+# https://streamlink.github.io/cli/plugins/twitch.html
+twitchaccountauth=XxX

--- a/streamlink-recorder.py
+++ b/streamlink-recorder.py
@@ -32,6 +32,7 @@ client_secret = ""
 token = ""
 slack_id = ""
 game_list = ""
+twitch_account_auth = ""
 
 def post_to_slack(message):
     """this function is in charge of the slack notification"""
@@ -127,6 +128,7 @@ def loopcheck():
         post_to_slack("recording " + user + " ...")
         print(user, "recording ... ")
         subprocess.call(["streamlink",
+                         "--twitch-api-header=Authorization=OAuth " + twitch_account_auth,
                          "--twitch-disable-hosting",
                          "--retry-max",
                          "5",
@@ -152,6 +154,7 @@ def main():
     global client_secret
     global slack_id
     global game_list
+    global twitch_account_auth
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -163,6 +166,7 @@ def main():
     parser.add_argument("-clientsecret", help="Your twitch app client secret")
     parser.add_argument("-slackid", help="Your slack app client id")
     parser.add_argument("-gamelist", help="The game list to be recorded")
+    parser.add_argument("-twitchaccountauth", help="Twitch personal account token. To disable embedded ads")
     args = parser.parse_args()
  
     if args.timer is not None:
@@ -175,6 +179,8 @@ def main():
         slack_id = args.slackid
     if args.gamelist is not None:
         game_list = args.gamelist
+    if args.twitchaccountauth is not None:
+        twitch_account_auth = args.twitchaccountauth
 
     if args.clientid is not None:
         client_id = args.clientid


### PR DESCRIPTION
# Issue

I found the ripped video containing embedded ads. This is due to absence of authorization. If I'm a subscriber, I can skip ads fully on watching the streamer. But this image doesn't send account information on ripping. That's why I made this PR.

# Solution

According to [documentations by Streamlink](https://streamlink.github.io/cli/plugins/twitch.html), we can put **Twitch Account Token**(which is different from client token) into Streamlink with `--twitch-api-header` option. So I added that argument on the image and python script

It works fine so far, but not sure that it works perfectly.
At least I checked it works normally even when account token is absent.