### PR TITLE
Implement real .mp4 conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 # Runner stage for the final image
 FROM base as runner
 COPY --from=builder /install /usr/local
+RUN apk add --no-cache ffmpeg
 COPY streamlink-recorder.py .
 COPY twitch_manager.py .
 COPY streamlink_manager.py .


### PR DESCRIPTION
This fixes the issue with the previous recording setup, which created "fake" .mp4 files that were actually .ts files.

Why:
- The old approach mislabeled .ts files as .mp4, causing slower playback
- The new approach provides a true .mp4 file.

1. **Switch to .ts Recording:** The system now records streams in the .ts format, which is what Streamlink natively provides.

2. **Real .mp4 Conversion:** After the recording finishes, the .ts file is properly converted to a real .mp4 using ffmpeg. This replaces the previous "fake" .mp4 files, which were simply .ts files incorrectly labeled as .mp4. 

3. **Post-recording Conversion with subprocess:** The conversion process runs in a separate subprocess, allowing the system to run the ffmpeg conversion without blocking the main process. This ensures that the system can start new recordings without delay, even if a stream starts while encoding is ongoing.


