### PR TITLE
fix: avoid exposing secrets in process args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ COPY notification_manager.py .
 RUN python -m pip uninstall -y pip setuptools \
     && rm -rf /usr/local/lib/python3.*/ensurepip
 
-# Set the entrypoint
-ENTRYPOINT python ./streamlink-recorder.py -user=${user} -timer=${timer} -quality=${quality} -clientid=${clientid} -clientsecret=${clientsecret} -slackid=${slackid} -gamelist="${gamelist}" -telegramchatid=${telegramchatid} -telegrambottoken=${telegrambottoken} -oauthtoken=${oauthtoken}
+# Set the entrypoint. Configuration is read from environment variables to avoid
+# exposing secrets in process arguments.
+ENTRYPOINT ["python", "./streamlink-recorder.py"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ git remote set-head origin -a
 
 # Notes
 
+## Next
+Secrets are now read directly from environment variables at runtime instead of being expanded into process arguments by the Docker entrypoint. This prevents Twitch/Telegram/Slack tokens from showing up in `ps` output. Notification HTTP error logs also redact token-bearing Telegram and Slack URLs.
+
+Recording failures are logged and the monitor loop continues checking instead of exiting the container.
+
 ## 4.0.0
 Update dependency streamlink to v8.0.0
 Removed deprecated `twitch-disable-hosting` and `twitch-disable-ads` options (handled automatically by Streamlink 8.x)
@@ -116,7 +121,7 @@ Keywords can always be used
 
 # Variables
 
-Environment variables are primarily used for Docker deployments. For Kubernetes/Helm deployments, configuration is managed via the `values.yaml` file and Kubernetes Secrets.
+Environment variables are primarily used for Docker deployments. For Kubernetes/Helm deployments, configuration is managed via the `values.yaml` file and Kubernetes Secrets. Secrets are read from the process environment at runtime and are not passed as command-line arguments.
 
 ## timer
 Specifies the interval (in seconds) to check for stream status.

--- a/notification_manager.py
+++ b/notification_manager.py
@@ -1,4 +1,5 @@
 import json
+import re
 import requests
 from abc import ABC, abstractmethod
 
@@ -6,6 +7,27 @@ import logging
 
 logger = logging.getLogger(__name__)
 from enum import Enum, auto
+
+
+def redact_url(url):
+    if not url:
+        return url
+
+    url = re.sub(r"(https://hooks\.slack\.com/services/)[^\s]+", r"\1<redacted>", url)
+    url = re.sub(r"(https://api\.telegram\.org/bot)[^/\s]+", r"\1<redacted>", url)
+    return url
+
+
+def log_http_error(service, exc):
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    reason = getattr(response, "reason", None)
+    url = redact_url(getattr(response, "url", None))
+
+    if response is not None:
+        logger.error("HTTP error occurred while sending message to %s: status=%s reason=%s url=%s", service, status_code, reason, url)
+    else:
+        logger.error("HTTP error occurred while sending message to %s: %s", service, redact_url(str(exc)))
 
 class NotifierType(Enum):
     SLACK = auto()
@@ -56,9 +78,9 @@ class SlackNotifier(Notifier):
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            logger.error(f"HTTP error occurred: {e}")
+            log_http_error("Slack", e)
         except Exception as e:
-            logger.error(f"Unexpected error occurred while sending message to Slack: {e}")
+            logger.error(f"Unexpected error occurred while sending message to Slack: {redact_url(str(e))}")
 
 class TelegramNotifier(Notifier):
     def __init__(self, bot_token, chat_id):
@@ -81,9 +103,9 @@ class TelegramNotifier(Notifier):
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            logger.error(f"HTTP error occurred: {e}")
+            log_http_error("Telegram", e)
         except Exception as exc:
-            logger.error(f"Unexpected error occurred while sending message to Telegram: {exc}")
+            logger.error(f"Unexpected error occurred while sending message to Telegram: {redact_url(str(exc))}")
 
 class NotifierFactory:
     _notifiers = {

--- a/streamlink-recorder.py
+++ b/streamlink-recorder.py
@@ -17,18 +17,31 @@ from notification_manager import NotificationManager
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+def env_or_arg(args, arg_name, *env_names, default=None):
+    value = getattr(args, arg_name)
+    if value not in (None, ""):
+        return value
+
+    for env_name in env_names:
+        value = os.getenv(env_name)
+        if value not in (None, ""):
+            return value
+
+    return default
+
+
 class AppConfig:
     def __init__(self, args):
-        self.timer = args.timer
-        self.user = args.user
-        self.quality = args.quality
-        self.client_id = args.clientid
-        self.client_secret = args.clientsecret
-        self.game_list = args.gamelist
-        self.slack_id = args.slackid
-        self.telegram_bot_token = args.telegrambottoken
-        self.telegram_chat_id = args.telegramchatid
-        self.oauth_token = args.oauthtoken
+        self.timer = int(env_or_arg(args, "timer", "timer", "TIMER", default=240))
+        self.user = env_or_arg(args, "user", "user", "TWITCH_USER")
+        self.quality = env_or_arg(args, "quality", "quality", "STREAM_QUALITY", default="720p60,720p,best")
+        self.client_id = env_or_arg(args, "clientid", "clientid", "TWITCH_CLIENT_ID")
+        self.client_secret = env_or_arg(args, "clientsecret", "clientsecret", "TWITCH_CLIENT_SECRET")
+        self.game_list = env_or_arg(args, "gamelist", "gamelist", "GAME_LIST", default="")
+        self.slack_id = env_or_arg(args, "slackid", "slackid", "SLACK_ID")
+        self.telegram_bot_token = env_or_arg(args, "telegrambottoken", "telegrambottoken", "TELEGRAM_BOT_TOKEN")
+        self.telegram_chat_id = env_or_arg(args, "telegramchatid", "telegramchatid", "TELEGRAM_CHAT_ID")
+        self.oauth_token = env_or_arg(args, "oauthtoken", "oauthtoken", "TWITCH_OAUTH_TOKEN")
 
 def loop_check(config):
     twitch_manager = TwitchManager(config)
@@ -45,27 +58,43 @@ def loop_check(config):
             message = f"Recording {config.user} ..."
             notifier_manager.notify_all(message)
             logger.info(message)
-            streamlink_manager.run_streamlink(config.user, recorded_filename)
-            message = f"Stream {config.user} is done. File saved as {filename}. Going back to checking.."
-            logger.info(message)
-            notifier_manager.notify_all(message)
+            try:
+                streamlink_manager.run_streamlink(config.user, recorded_filename)
+            except Exception as exc:
+                logger.exception("Failed to record %s: %s", config.user, exc)
+                notifier_manager.notify_all(f"Failed to record {config.user}. Going back to checking...")
+            else:
+                message = f"Stream {config.user} is done. File saved as {filename}. Going back to checking.."
+                logger.info(message)
+                notifier_manager.notify_all(message)
         time.sleep(config.timer)
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-timer", type=int, default=240, help="Stream check interval (less than 15s are not recommended)")
-    parser.add_argument("-user", required=True, help="Twitch user that we are checking")
-    parser.add_argument("-quality", default="720p60,720p,best", help="Recording quality")
-    parser.add_argument("-clientid", required=True, help="Your Twitch app client id")
-    parser.add_argument("-clientsecret", required=True, help="Your Twitch app client secret")
+    parser.add_argument("-timer", type=int, help="Stream check interval (less than 15s are not recommended)")
+    parser.add_argument("-user", help="Twitch user that we are checking")
+    parser.add_argument("-quality", help="Recording quality")
+    parser.add_argument("-clientid", help="Your Twitch app client id")
+    parser.add_argument("-clientsecret", help="Your Twitch app client secret")
     parser.add_argument("-slackid", help="Your slack app client id")
-    parser.add_argument("-gamelist", default="", help="The game list to be recorded")
+    parser.add_argument("-gamelist", help="The game list to be recorded")
     parser.add_argument("-telegrambottoken", help="Your Telegram bot token")
     parser.add_argument("-telegramchatid", help="Your Telegram chat ID where the bot will send messages")
     parser.add_argument("-oauthtoken", help="Your OAuth token for Twitch API")
     args = parser.parse_args()
+    config = AppConfig(args)
 
-    return AppConfig(args)
+    missing = []
+    if not config.user:
+        missing.append("user")
+    if not config.client_id:
+        missing.append("clientid/TWITCH_CLIENT_ID")
+    if not config.client_secret:
+        missing.append("clientsecret/TWITCH_CLIENT_SECRET")
+    if missing:
+        parser.error(f"missing required configuration: {', '.join(missing)}")
+
+    return config
 
 def main():
     config = parse_arguments()

--- a/test_notification_manager.py
+++ b/test_notification_manager.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import MagicMock
+
+import requests
+
+from notification_manager import redact_url, log_http_error
+
+
+class TestNotificationManager(unittest.TestCase):
+    def test_redact_url_redacts_telegram_bot_token(self):
+        url = "https://api.telegram.org/bot123456:secret/sendMessage"
+        self.assertEqual(redact_url(url), "https://api.telegram.org/bot<redacted>/sendMessage")
+
+    def test_redact_url_redacts_slack_webhook_secret(self):
+        url = "https://hooks.slack.com/services/T000/B000/SECRET"
+        self.assertEqual(redact_url(url), "https://hooks.slack.com/services/<redacted>")
+
+    def test_log_http_error_does_not_log_secret_url(self):
+        response = MagicMock()
+        response.status_code = 401
+        response.reason = "Unauthorized"
+        response.url = "https://api.telegram.org/bot123456:secret/sendMessage"
+        exc = requests.exceptions.HTTPError(response=response)
+
+        with self.assertLogs("notification_manager", level="ERROR") as captured:
+            log_http_error("Telegram", exc)
+
+        rendered = "\n".join(captured.output)
+        self.assertIn("bot<redacted>", rendered)
+        self.assertNotIn("123456:secret", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Read recorder configuration directly from environment variables so Kubernetes/Docker secrets are not expanded into process arguments
- Redact token-bearing Slack and Telegram URLs from notification HTTP error logs
- Keep the monitor loop alive when a recording attempt fails, so a transient Twitch/Streamlink error does not crash-loop the pod
- Document the secret-handling change and add notification redaction tests

## Validation
- `python3 -m py_compile streamlink-recorder.py notification_manager.py streamlink_manager.py twitch_manager.py`
- Could not run full unit tests in this workspace because Python dependencies (`requests`, `streamlink`) are not installed and no pip/uv is available.